### PR TITLE
Add error details to Consul error log

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -63,7 +63,7 @@ func watchConsulService(ctx context.Context, s servicer, tgt target, out chan<- 
 				},
 			)
 			if err != nil {
-				grpclog.Errorf("[Consul resolver] Couldn't fetch endpoints. target={%s}", tgt.String())
+				grpclog.Errorf("[Consul resolver] Couldn't fetch endpoints. target={%s}; error={%v}", tgt.String(), err)
 				time.Sleep(bck.Duration())
 				continue
 			}


### PR DESCRIPTION
Hello 👋 🙂 

I was using the library and got some error logs, but didn't know what exactly was wrong, so I added the error details to the log message.

With the change the logs will look like:
- `[Consul resolver] Couldn't fetch endpoints. target={service='my-service' healthy='true' tag='grpc'}; error={Get "http://127.0.0.1:8500/v1/health/service/my-service?near=_agent&passing=1&tag=grpc": dial tcp 127.0.0.1:8500: connect: connection refused}`, when Consul doesn't run
- `[Consul resolver] Couldn't fetch endpoints. target={service='my-service' healthy='true' tag='grpc'}; error={Get "http://127.0.0.1:8500/v1/health/service/my-service?near=_agent&passing=1&tag=grpc": EOF}` When Consul is having issues (potentially due to too many concurrent connections)
- etc

This is useful to differentiate between the different error causes and to decide whether a specific error log requires action or not.

Regarding some details:

- I chose `%v` instead of `%s` for the error because that's what I came across more often for logging errors
- I chose `;` as separator between the details instead of `.` because that nicely separates the message from the two details

In the long term a way to use a custom logger could be nice to have structured logging, but I'm not sure how feasible that is given that this library is included with `import _ "..."`, so might already start logging before any code for passing/injecting a custom logger is run. For now having the error details like this already helps.

Feel free to suggest improvements or ask questions! Or decline the PR if you don't need/want this 🙂 .
