### PR TITLE
Fix discovery not stopping despite being cancelled

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -97,13 +97,20 @@ func watchConsulService(ctx context.Context, s servicer, tgt target, out chan<- 
 	}()
 
 	for {
+		// If in the below select both channels have values that can be read,
+		// Go picks one pseudo-randomly.
+		// But when the context is canceled we want to act upon it immediately.
+		if ctx.Err() != nil {
+			// Close quit so the goroutine returns and doesn't leak.
+			// Do NOT close res because that can lead to panics in the goroutine.
+			// res will be garbage collected at some point.
+			close(quit)
+			return
+		}
 		select {
 		case ee := <-res:
 			out <- ee
 		case <-ctx.Done():
-			// Close quit so the goroutine returns and doesn't leak.
-			// Do NOT close res because that can lead to panics in the goroutine.
-			// res will be garbage collected at some point.
 			close(quit)
 			return
 		}

--- a/consul.go
+++ b/consul.go
@@ -66,9 +66,10 @@ func watchConsulService(ctx context.Context, s servicer, tgt target, out chan<- 
 				// No need to continue if the context is done/cancelled.
 				// We check that here directly because the check for the closed quit channel
 				// at the end of the loop is not reached when calling continue here.
-				if ctx.Err() != nil {
+				select {
+				case <-quit:
 					return
-				} else {
+				default:
 					grpclog.Errorf("[Consul resolver] Couldn't fetch endpoints. target={%s}; error={%v}", tgt.String(), err)
 					time.Sleep(bck.Duration())
 					continue

--- a/consul.go
+++ b/consul.go
@@ -63,9 +63,16 @@ func watchConsulService(ctx context.Context, s servicer, tgt target, out chan<- 
 				},
 			)
 			if err != nil {
-				grpclog.Errorf("[Consul resolver] Couldn't fetch endpoints. target={%s}; error={%v}", tgt.String(), err)
-				time.Sleep(bck.Duration())
-				continue
+				// No need to continue if the context is done/cancelled.
+				// We check that here directly because the check for the closed quit channel
+				// at the end of the loop is not reached when calling continue here.
+				if ctx.Err() != nil {
+					return
+				} else {
+					grpclog.Errorf("[Consul resolver] Couldn't fetch endpoints. target={%s}; error={%v}", tgt.String(), err)
+					time.Sleep(bck.Duration())
+					continue
+				}
 			}
 			bck.Reset()
 			lastIndex = meta.LastIndex


### PR DESCRIPTION
Hello 👋 🙂 ,

We noticed a small issue with the library. I tried to fix it in a fork and the fix seems to work. With this PR I'm proposing to add the fix to your upstream library.

When calling `Close` on a gRPC client connection, grpc-go calls the resolver's `Close` method (via a wrapper call [here](https://github.com/grpc/grpc-go/blob/dc77d7ffe311f78f2e577572d984af3c0a8df82b/clientconn.go#L1050)), which in case of this library leads to the context being cancelled ([here](https://github.com/mbobakov/grpc-consul-resolver/blob/36e23056d823e66b207ded981f2528aa49c0d30b/consul.go#L31)). But in one case the cancellation is not noticed and in another it can be delayed:

1. When the Consul library returns an error, it was logged with `grpclog.Errorf` and then `continue` was used. With this continue we go to the beginning of the `for` loop, never checking whether the `quit` channel was closed.
    - The continue [here](https://github.com/mbobakov/grpc-consul-resolver/blob/36e23056d823e66b207ded981f2528aa49c0d30b/consul.go#L68)
    - The check [here](https://github.com/mbobakov/grpc-consul-resolver/blob/36e23056d823e66b207ded981f2528aa49c0d30b/consul.go#L93-L94) is never reached 
2. Upon context cancellation, the context's `Done` channel is closed and it's checked in the goroutine that's responsible for closing the `quit` channel [here](https://github.com/mbobakov/grpc-consul-resolver/blob/36e23056d823e66b207ded981f2528aa49c0d30b/consul.go#L103-L108), but with `select` _randomly_ reading from one of the channels that have a value, the stopping can be delayed a bit despite the context being cancelled already.
    - Source regarding the randomness: https://golang.org/ref/spec#Select_statements 

Point 1 is probably not affecting a lot of users in production, but we use it in a test setup where we want to prevent the `grpclog.Errorf` to be called when the context is cancelled.

I think 2 is not too bad - the random choosing will eventually pick the case with the closed `Done` channel, so I'm open to removing that change from the PR.

Let me know if you think the code comments are too extensive as well, maybe we can come up with a shorter summary of why the new condition checks are done.