### PR TITLE
fix: invalid address when service using auto port mapping

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -89,6 +89,10 @@ func watchConsulService(ctx context.Context, s servicer, tgt target, out chan<- 
 				if s.Service.Address == "" {
 					address = s.Node.Address
 				}
+				if s.Service.Port == 0 {
+					ee = append(ee, fmt.Sprintf("%s", address))
+					continue
+				}
 				ee = append(ee, fmt.Sprintf("%s:%d", address, s.Service.Port))
 			}
 


### PR DESCRIPTION
When the service listens using address :0 for automatic port mapping, the api.AgentService will have Port:0, Address:[::]:58307. Therefore, the address mapping in this case will resolve as [::]:58307:0, which is invalid.
The solution
```
if s.Service.Port == 0 {
	ee = append(ee, fmt.Sprintf("%s", address))
	xcontinue
}
ee = append(ee, fmt.Sprintf("%s:%d", address, s.Service.Port))
```
